### PR TITLE
Increase zlib outbuffer size. Insufficient for E5787Ph firmware file.

### DIFF
--- a/ptable.c
+++ b/ptable.c
@@ -238,11 +238,11 @@ if ((*(uint16_t*)ptable[npart].pimage) == 0xda78) {
 
 if ((ptable[npart].pimage[0] == 0x5d) && (*(uint64_t*)(ptable[npart].pimage+5) == 0xffffffffffffffff)) {
   ptable[npart].zflag=ptable[npart].hd.psize;  // сохраняем сжатый размер 
-  zlen=52428800;
-  zbuf=malloc(zlen);  // буфер в 50М
+  zlen=100 * 1024 * 1024;
+  zbuf=malloc(zlen);  // буфер в 100М
   // распаковываем образ раздела
   zlen=lzma_decode(ptable[npart].pimage, ptable[npart].hd.psize, zbuf);
-  if (zlen>52428800) {
+  if (zlen>100 * 1024 * 1024) {
     printf("\n Превышен размер буфера\n");
     exit(1);
   }  


### PR DESCRIPTION
E5787Ph-67a_UPDATE_21.235.01.00.302_WEBUI_21.100.19.00.302_NE5.7Z requires more than 50 MiB to extract `system` partition.
Its size is 96810496 bytes (96 MB / 92 MiB).